### PR TITLE
64-Bit support for Import-VisualStudioEnvironment

### DIFF
--- a/Code/Import-VisualStudioEnvironment.psm1
+++ b/Code/Import-VisualStudioEnvironment.psm1
@@ -99,7 +99,14 @@ https://github.com/Wintellect/WintellectPowerShell
         [string] $Architecture = ($Env:PROCESSOR_ARCHITECTURE)
     )  
 
-    $versionSearchKey = "HKLM:\SOFTWARE\Microsoft\VisualStudio\SxS\VS7"
+    if ([IntPtr]::size -eq 8)
+    {
+        $versionSearchKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7"
+    }
+    else
+    {
+        $versionSearchKey = "HKLM:\SOFTWARE\Microsoft\VisualStudio\SxS\VS7"
+    }
     $vsDirectory = ""
 
     if ($VSVersion -eq 'Latest')


### PR DESCRIPTION
On 64-Bit machines starting a 64-Bit Powershell process the
$versionSearchKey links into the 64-Bit part of the Registry on HKLM.
Because VisualStudio is a 32-Bit Project a "Wow6432Node" Search key is
neccessary.
