### PR TITLE
Fixed HandleCSharpMainProperties to support Script Blocks

### DIFF
--- a/Code/Set-ProjectProperties.ps1
+++ b/Code/Set-ProjectProperties.ps1
@@ -8,7 +8,7 @@
 
 # Always make sure all variables are defined and all best practices are 
 # followed.
-Set-StrictMode  –version Latest 
+Set-StrictMode  â€“version Latest 
 
 ###############################################################################
 # Script Global Variables
@@ -263,39 +263,39 @@ http://code.wintellect.com
             # Enumerate through the property keys.
             foreach ($item in $newMainProps.GetEnumerator())
             {
-                switch ($item.Key)
+                if ($item.Key -eq "AssemblyOriginatorKeyFile")
                 {
-                    "AssemblyOriginatorKeyFile" 
+                    # Get the full path to the .SNK file specified.
+                    $snkFile = Resolve-Path -Path $item.Value -ErrorAction SilentlyContinue
+
+                    if ($null -eq $snkFile)
                     {
-                        # Get the full path to the .SNK file specified.
-                        $snkFile = Resolve-Path -Path $item.Value -ErrorAction SilentlyContinue
-
-                        if ($null -eq $snkFile)
-                        {
-                            [string]$inputFile = $item.Value
-                            throw "Unable to find $inputFile, Please specify the full path to the file."
-                        }
-
-                        ReplaceRelativePathNode -fileLocation $file `
-                                                -document $fileXML `
-                                                -topElement $mainProps `
-                                                -elementName "AssemblyOriginatorKeyFile" `
-                                                -fullUseFilePath $snkFile
-
-                        # In case the user forgot, set the option to use the SNK file also.
-                        ReplaceNode -document $fileXML `
-                                    -topElement $mainProps `
-                                    -elementName "SignAssembly" `
-                                    -elementValue "true"
+                        [string]$inputFile = $item.Value
+                        throw "Unable to find $inputFile, Please specify the full path to the file."
                     }
 
-                    default
-                    {
-                        ReplaceNode -document $fileXML `
-                                    -topElement $mainProps `
-                                    -elementName $item.Key `
-                                    -elementValue $item.Value
-                    }
+                    ReplaceRelativePathNode -fileLocation $file `
+                                            -document $fileXML `
+                                            -topElement $mainProps `
+                                            -elementName "AssemblyOriginatorKeyFile" `
+                                            -fullUseFilePath $snkFile
+
+                    # In case the user forgot, set the option to use the SNK file also.
+                    ReplaceNode -document $fileXML `
+                                -topElement $mainProps `
+                                -elementName "SignAssembly" `
+                                -elementValue "true"
+                }
+                elseif ($item.Value -is [scriptblock])
+                {
+                    & $item.Value $mainProps
+                }
+								else
+                {
+                    ReplaceNode -document $fileXML `
+                                -topElement $mainProps `
+                                -elementName $item.Key `
+                                -elementValue $item.Value
                 }
             }
         }


### PR DESCRIPTION
I noticed that the inline documentation for this script [implies that both `CustomGeneralProperties` and `CustomConfigurationProperties` support script blocks](https://github.com/Wintellect/WintellectPowerShell/blob/master/Code/Set-ProjectProperties.ps1#L116-L130) but I discovered through trial and error that script blocks only worked with `CustomConfigurationProperties`. 

When I looked at the code I realized that `HandleCSharpConfigProperties` used an if/else/else block which checked to see if the `$item` was a script block but `HandleCSharpMainProperties` used a switch on the value and never checked if `$item` was a script block.

This commit transposed the 
```
                elseif ($item.Value -is [scriptblock])
                {
                    & $item.Value $configGroup
                }
```
pattern from  [`HandleCSharpConfigProperties`](https://github.com/Wintellect/WintellectPowerShell/blob/master/Code/Set-ProjectProperties.ps1#L358-L361) into `HandleCSharpMainProperties`