### PR TITLE
Support VS2019 in Impor-VisualStudioEnvironment and so on

### DIFF
--- a/Code/Add-NgenPdbs.ps1
+++ b/Code/Add-NgenPdbs.ps1
@@ -84,47 +84,55 @@ https://github.com/Wintellect/WintellectPowerShell
         }
 
         $vsVersion = $null
-        $symPath = $symServs["VS 2017"]
+        $symPath = $symServs["VS 2019"]
         if ($null -eq $symPath)
         {
-            $symPath = $symServs["VS 2015"]
+            $symPath = $symServs["VS 2017"]
             if ($null -eq $symPath)
             {
-                $symPath = $symServs["VS 2013"]
+                $symPath = $symServs["VS 2015"]
                 if ($null -eq $symPath)
                 {
-                    # Pull it out of _NT_SYMBOL_PATH. Yes this is only looking at the
-                    # first cache directory specified.
-                    $symPath = $symServs["_NT_SYMBOL_PATH"]
+                    $symPath = $symServs["VS 2013"]
                     if ($null -eq $symPath)
                     {
-                        throw "No symbol server configured"
-                    }
-                    else
-                    {
-                        if ($symPath -match "SRV\*(?<SymCache>[^*]*)\*(?:.*)\;?")
+                        # Pull it out of _NT_SYMBOL_PATH. Yes this is only looking at the
+                        # first cache directory specified.
+                        $symPath = $symServs["_NT_SYMBOL_PATH"]
+                        if ($null -eq $symPath)
                         {
-                            $symPath = $Matches["SymCache"]
+                            throw "No symbol server configured"
                         }
                         else
                         {
-                            throw "_NT_SYMBOL_PATH environment variable does not specify a symbol cache"
+                            if ($symPath -match "SRV\*(?<SymCache>[^*]*)\*(?:.*)\;?")
+                            {
+                                $symPath = $Matches["SymCache"]
+                            }
+                            else
+                            {
+                                throw "_NT_SYMBOL_PATH environment variable does not specify a symbol cache"
+                            }
                         }
+                    }
+                    else
+                    {
+                        $vsVersion = "2013"
                     }
                 }
                 else
                 {
-                    $vsVersion = "2013"
+                    $vsVersion = "2015"
                 }
             }
             else
             {
-                $vsVersion = "2015"
+                $vsVersion = "2017"
             }
         }
         else
         {
-            $vsVersion = "2017"
+            $vsVersion = "2019"
         }
 
         if ($null -ne $vsVersion)

--- a/Code/Import-VisualStudioEnvironment.ps1
+++ b/Code/Import-VisualStudioEnvironment.ps1
@@ -1,4 +1,4 @@
-#requires -version 5.0
+﻿#requires -version 5.0
 ###############################################################################
 # WintellectPowerShell Module
 # Copyright (c) 2010-2017 - John Robbins/Wintellect
@@ -36,7 +36,7 @@ VS110COMNTOOLS.
 .PARAMETER VSVersion
 The version of Visual Studio you want to use. If left to the default, Latest, the
 script will look for the latest version of Visual Studio installed on the computer
-as the tools to use. Specify 2013, 2015, or 2017 for a specific version.
+as the tools to use. Specify 2013, 2015, 2017, or 2019 for a specific version.
 
 .PARAMETER Architecture
 The tools architecture to use. This defaults to the $env:PROCESSOR_ARCHITECTURE 

--- a/Code/Import-VisualStudioEnvironment.ps1
+++ b/Code/Import-VisualStudioEnvironment.ps1
@@ -1,4 +1,4 @@
-﻿#requires -version 5.0
+#requires -version 5.0
 ###############################################################################
 # WintellectPowerShell Module
 # Copyright (c) 2010-2017 - John Robbins/Wintellect
@@ -66,7 +66,7 @@ https://github.com/Wintellect/WintellectPowerShell
     param
     (
         [Parameter(Position=0)]
-        [ValidateSet("Latest", "2013", "2015", "2017")]
+        [ValidateSet("Latest", "2013", "2015", "2017", "2019")]
         [string] $VSVersion = "Latest", 
         [Parameter(Position=1)]
         [ValidateSet("x86", "amd64", "arm")]
@@ -109,6 +109,7 @@ https://github.com/Wintellect/WintellectPowerShell
                         "2013" { "12.0" }
                         "2015" { "14.0" }
                         "2017" { "15.0" }
+                        "2019" { "16.0" }
                         default { throw "Unknown version of Visual Studio!" }
                     }
 

--- a/Code/Import-VisualStudioEnvironment.ps1
+++ b/Code/Import-VisualStudioEnvironment.ps1
@@ -1,4 +1,4 @@
-﻿#requires -version 5.0
+#requires -version 5.0
 ###############################################################################
 # WintellectPowerShell Module
 # Copyright (c) 2010-2017 - John Robbins/Wintellect
@@ -75,7 +75,7 @@ https://github.com/Wintellect/WintellectPowerShell
     )  
 
     # VS2017+
-    $vswherePath = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 
     # for VS2017 and older
     $versionSearchKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7"

--- a/Code/Internal.ps1
+++ b/Code/Internal.ps1
@@ -94,7 +94,7 @@ function Get-RegistryKeyPropertiesAndValues
 function LatestVSRegistryKeyVersion
 {
     # 2017+
-    $vswherePath = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     # 2017 and older
     $versionSearchKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7"
     if ([IntPtr]::size -ne 8)

--- a/Code/SymbolsSource.ps1
+++ b/Code/SymbolsSource.ps1
@@ -14,7 +14,7 @@ Set-StrictMode -version Latest
 # Script Global Variables
 ###############################################################################
 # The array that contains all the versions.
-$script:vsVersionArray = "2012", "2013", "2015", "2017" 
+$script:vsVersionArray = "2012", "2013", "2015", "2017", "2019"
 
 ###############################################################################
 # Module Only Functions


### PR DESCRIPTION
Closes #12 

We seem to have to use https://github.com/microsoft/vswhere to detect VS2019+.
I confirmed `Import-VisualStudioEnvironment` and `Import-VisualStudioEnvironment -VsVersion 2019` work properly and `Import-VisualStudioEnvironment -VsVersion 2017` successfully complains VS2017 is not installed. (I have installed only VS2019)

Could you sign my modification?  I don't mind your modification on the branch in my forked reposittory.